### PR TITLE
Fix parameter to be compatible with composer 2

### DIFF
--- a/src/CasperJsInstaller/Installer.php
+++ b/src/CasperJsInstaller/Installer.php
@@ -54,7 +54,7 @@ class Installer
         // Download the Archive
 
         $downloadManager = $composer->getDownloadManager();
-        $downloadManager->download($package, $targetDir, false);
+        $downloadManager->download($package, $targetDir, null);
 
         // Create CasperJS launcher in the "bin" folder
         self::createCasperJsBinaryToBinFolder($targetDir, $binDir);


### PR DESCRIPTION
This fix a issue when running the package user composer 2:

```
Fatal error: Uncaught TypeError: Argument 3 passed to Composer\Downloader\DownloadManager::download() must implement interface Composer\Package\PackageInterface or be null, bool given, called in xxx/vendor/jerome-breton/casperjs-installer/src/CasperJsInstaller/Installer.php on line 57 and defined in phar:///xxxx/composer.phar/src/Composer/Downloader/DownloadManager.php:182
```
